### PR TITLE
Fix service name after unplanned update SNOW side

### DIFF
--- a/pkg/in/api.go
+++ b/pkg/in/api.go
@@ -109,7 +109,7 @@ func parseIncident(input string) (*Incident, error) {
 		i.Service = "59"
 	case "Cyclamen IT Platform Local":
 		i.Service = "9"
-	case "I-LEAP":
+	case "PPPT - ILEAP":
 		i.Service = "58"
 	case "Semaphore":
 		i.Service = "45"
@@ -117,7 +117,7 @@ func parseIncident(input string) (*Incident, error) {
 		i.Service = "65"
 	}
 
-	fmt.Printf("parsed incident: %v, status: %v, comment id: %v\n", i.Identifier, i.Status, i.CommentID)
+	fmt.Printf("parsed incident: %v from %v, status: %v, comment id: %v\n", i.IntID, i.Service, i.Status, i.CommentID)
 
 	return i, nil
 }

--- a/pkg/out/api.go
+++ b/pkg/out/api.go
@@ -80,7 +80,7 @@ func parseIncident(input string) (*Incident, error) {
 	case "9":
 		i.Service = "Cyclamen IT Platform Local"
 	case "58":
-		i.Service = "I-LEAP"
+		i.Service = "PPPT - ILEAP"
 	case "45":
 		i.Service = "Semaphore"
 	default:
@@ -129,7 +129,7 @@ func parseIncident(input string) (*Incident, error) {
 		return nil, nil
 	}
 
-	fmt.Printf("parsed incident: %v, status: %v, comment id: %v\n", i.Identifier, i.Status, i.CommentID)
+	fmt.Printf("parsed incident: %v from %v, status: %v, comment id: %v\n", i.ExtID, i.Service, i.Status, i.CommentID)
 
 	return i, nil
 }


### PR DESCRIPTION
Update service name after it was changed on SNOW.
Also fixes logging of parsed tickets.